### PR TITLE
Bugfix DoguRegistry IsEnabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Fixed
+- [#6] DoguRegistry method IsEnabled returns an error when the configmap for the spec is not available - now it returns false instead
 
 ## [v0.2.0] - 2024-07-12
 ### Added

--- a/dogu/localRegistry.go
+++ b/dogu/localRegistry.go
@@ -180,8 +180,12 @@ func (cmr *LocalDoguRegistry) GetCurrentOfAll(ctx context.Context) ([]*core.Dogu
 // by verifying that the specLocation field in the dogu resource's status is set.
 func (cmr *LocalDoguRegistry) IsEnabled(ctx context.Context, simpleDoguName string) (bool, error) {
 	specConfigMap, err := cmr.getSpecConfigMapForDogu(ctx, simpleDoguName)
+	if k8sErrs.IsNotFound(err) {
+		return false, nil
+	}
+
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("unable to get configmap for spec of dogu %s: %w", simpleDoguName, err)
 	}
 
 	_, enabled := specConfigMap.Data[currentVersionKey]

--- a/dogu/localRegistry_test.go
+++ b/dogu/localRegistry_test.go
@@ -521,6 +521,20 @@ func Test_clusterNativeLocalDoguRegistry_IsEnabled(t *testing.T) {
 			},
 		},
 		{
+			name: "should return false in case config map is not available",
+			configMapClientFn: func(t *testing.T) configMapClient {
+				cmClient := newMockConfigMapClient(t)
+				cmClient.EXPECT().Get(testCtx, "dogu-spec-ldap", metav1.GetOptions{}).Return(nil, k8sErrs.NewNotFound(schema.GroupResource{}, ""))
+				return cmClient
+			},
+			simpleDoguName: "ldap",
+			want:           false,
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				assert.NoError(t, err)
+				return true
+			},
+		},
+		{
 			name: "should return false",
 			configMapClientFn: func(t *testing.T) configMapClient {
 				configMap := &corev1.ConfigMap{Data: map[string]string{}}


### PR DESCRIPTION
When spec for a dogu is not available this also means that es dogu is not enabled yet. In this case return false instead of an error.

Resolve #6 